### PR TITLE
Sharding manifest + person→file locator for large trees

### DIFF
--- a/scripts/shard_manifest.py
+++ b/scripts/shard_manifest.py
@@ -23,7 +23,7 @@ Behavior:
 - If `Family_Tree.md` (or the File/Region table) is absent, `load_shard_manifest`
   returns {} and `region_for` falls back to a generic label. The scripts still
   run on a single un-sharded `Family_Tree.md` with no configuration.
-- `region_for` matches a Person_Index section header (a shard file basename) to
+- `region_for` matches a shard file basename to
   the LONGEST manifest key that is a prefix of it, so a master entry
   (`Family_Tree_Maternal`) covers its children (`Family_Tree_Maternal_Highland`)
   without listing each, while a more specific entry
@@ -107,18 +107,18 @@ def load_shard_manifest(vault_dir: str) -> dict:
     return manifest
 
 
-def region_for(section: str, manifest: dict) -> str:
-    """Classify a Person_Index section header (shard basename) into a region.
+def region_for(basename: str, manifest: dict) -> str:
+    """Classify a shard file basename into a region.
 
     Longest-prefix match against the manifest; generic fallback otherwise."""
-    section = section.strip()
+    basename = basename.strip()
     best_key = None
     for key in manifest:
-        if section == key or section.startswith(key + "_"):
+        if basename == key or basename.startswith(key + "_"):
             if best_key is None or len(key) > len(best_key):
                 best_key = key
     if best_key is not None:
         return manifest[best_key]
-    if section.startswith(TREE_PREFIX):
+    if basename.startswith(TREE_PREFIX):
         return MAIN_REGION
     return OTHER_REGION

--- a/scripts/shard_manifest.py
+++ b/scripts/shard_manifest.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Shard-manifest loader for sharded family-tree vaults.
+
+A growing tree is typically capped at N generations in `Family_Tree.md` and the
+rest split into branch/region files (`Family_Tree_<Region>.md`). Rather than
+hardcode any particular project's shard names, the audit scripts read an
+OPTIONAL manifest declared inside `Family_Tree.md`: a markdown table that has a
+`File` column and a `Region` column. Each row maps a shard file to the region
+label the scripts should group it under.
+
+Example (place anywhere in Family_Tree.md):
+
+    ## File Index
+
+    | File | Region | Content |
+    |---|---|---|
+    | [[Family_Tree_Maternal_Highland]] | Highland | ... |
+    | [[Family_Tree_Paternal_Coastal]]  | Coastal  | ... |
+    | [[Family_Tree_Colonial_North]]    | Colonial | ... |
+
+Behavior:
+- If `Family_Tree.md` (or the File/Region table) is absent, `load_shard_manifest`
+  returns {} and `region_for` falls back to a generic label. The scripts still
+  run on a single un-sharded `Family_Tree.md` with no configuration.
+- `region_for` matches a Person_Index section header (a shard file basename) to
+  the LONGEST manifest key that is a prefix of it, so a master entry
+  (`Family_Tree_Maternal`) covers its children (`Family_Tree_Maternal_Highland`)
+  without listing each, while a more specific entry
+  (`Family_Tree_Paternal_Coastal`) overrides a broader one
+  (`Family_Tree_Paternal`).
+
+This module is data-driven and contains no project-specific names, so it is
+safe to contribute upstream; the actual shard->region mappings live in the
+vault's Family_Tree.md.
+"""
+
+import os
+import re
+
+# Generic label for the un-sharded main file (and any shard not in the manifest
+# whose name still begins with the family-tree prefix).
+MAIN_REGION = "Family_Tree (main)"
+OTHER_REGION = "Other"
+TREE_PREFIX = "Family_Tree"
+
+_SEPARATOR_RE = re.compile(r"^\s*\|?[\s:\-|]+\|?\s*$")
+
+
+def _cells(line: str):
+    """Split a markdown table row into trimmed cell strings."""
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def _normalize_file(cell: str) -> str:
+    """Reduce a File-column cell to a bare shard basename.
+
+    Handles `[[Family_Tree_X]]` wikilinks, `Family_Tree_X.md`, backtick-wrapped
+    names, and markdown links `[label](path)`."""
+    s = cell.strip()
+    # markdown link [text](target) -> prefer the link text
+    m = re.match(r"\[([^\]]+)\]\([^)]*\)", s)
+    if m:
+        s = m.group(1)
+    s = s.strip("`").strip()
+    s = s.replace("[[", "").replace("]]", "")
+    s = re.sub(r"\.md\b", "", s)
+    # drop any leading path
+    s = s.rsplit("/", 1)[-1]
+    return s.strip()
+
+
+def load_shard_manifest(vault_dir: str) -> dict:
+    """Parse `<vault>/Family_Tree.md` for a File/Region table.
+
+    Returns {shard_basename: region}. Empty dict if no manifest is found."""
+    path = os.path.join(vault_dir, "Family_Tree.md")
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        lines = f.readlines()
+
+    manifest: dict = {}
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "|" in line:
+            headers = [c.lower() for c in _cells(line)]
+            if "file" in headers and "region" in headers:
+                file_idx = headers.index("file")
+                region_idx = headers.index("region")
+                i += 1
+                # skip the |---|---| separator row if present
+                if i < len(lines) and _SEPARATOR_RE.match(lines[i]):
+                    i += 1
+                # consume contiguous table rows
+                while i < len(lines) and lines[i].lstrip().startswith("|"):
+                    cells = _cells(lines[i])
+                    if len(cells) > max(file_idx, region_idx):
+                        fname = _normalize_file(cells[file_idx])
+                        region = cells[region_idx].strip()
+                        if fname and region:
+                            manifest[fname] = region
+                    i += 1
+                break
+        i += 1
+    return manifest
+
+
+def region_for(section: str, manifest: dict) -> str:
+    """Classify a Person_Index section header (shard basename) into a region.
+
+    Longest-prefix match against the manifest; generic fallback otherwise."""
+    section = section.strip()
+    best_key = None
+    for key in manifest:
+        if section == key or section.startswith(key + "_"):
+            if best_key is None or len(key) > len(best_key):
+                best_key = key
+    if best_key is not None:
+        return manifest[best_key]
+    if section.startswith(TREE_PREFIX):
+        return MAIN_REGION
+    return OTHER_REGION

--- a/scripts/tree_locator.py
+++ b/scripts/tree_locator.py
@@ -25,9 +25,6 @@ Modes:
                  * people appearing in >1 shard file (ambiguous / possible dup)
                  * shard files on disk not declared in the manifest (no region)
                  * manifest entries with no matching file on disk
-               and, only IF a Person_Index.md is present, an optional drift pass:
-                 * shard people with no Person_Index row
-                 * Person_Index names absent from every shard
                --check exits 1 when any issue is found, else 0.
 
 Generic: contains no project-specific names. Pairs with shard_manifest.py as the
@@ -46,7 +43,7 @@ import shard_manifest
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_VAULT = os.path.join(os.path.dirname(SCRIPT_DIR), "vault")
 
-# Bold-name narrative entry header — same shape used across the audit suite:
+# Bold-name narrative entry header — the convention this toolkit keys on:
 #   "**Full Name** ( ... )"  or  "**Full Name ( ... )**"
 # Require a proper-noun first token (Cap + lowercase) so all-caps labels
 # ("SECOND MARRIAGE", "FS-attached") are not mistaken for people.
@@ -154,31 +151,6 @@ def _flat(index):
     return rows
 
 
-# ----- lenient Person_Index parse (optional cross-check only) ----------------
-# Schema-tolerant: any markdown table row's FIRST cell is taken as the person
-# name. Does not assume a column count, so it works across index variants.
-_SEP_RE = re.compile(r"^\s*\|?[\s:\-|]+\|?\s*$")
-
-
-def read_person_index_names(vault):
-    """Return set of names from Person_Index.md, or None if the file is absent."""
-    path = os.path.join(vault, "Person_Index.md")
-    if not os.path.exists(path):
-        return None
-    names = set()
-    with open(path, encoding="utf-8") as f:
-        for line in f:
-            s = line.strip()
-            if not s.startswith("|") or _SEP_RE.match(line):
-                continue
-            first = s.strip("|").split("|", 1)[0].strip().strip("*").strip()
-            # skip the header row and empty cells
-            if not first or first.lower() in {"name", "person"}:
-                continue
-            names.add(first)
-    return names
-
-
 def main():
     ap = argparse.ArgumentParser(description="Derive a person->shard-file locator from a sharded family tree.")
     ap.add_argument("--vault", default=DEFAULT_VAULT, help="Path to the vault directory (default: ../vault).")
@@ -192,7 +164,7 @@ def main():
     index, manifest, files_on_disk = build_index(args.vault)
 
     if args.check:
-        return run_check(index, manifest, files_on_disk, args.vault)
+        return run_check(index, manifest, files_on_disk)
 
     rows = _flat(index)
     if args.region:
@@ -228,7 +200,7 @@ def main():
     return 0
 
 
-def run_check(index, manifest, files_on_disk, vault):
+def run_check(index, manifest, files_on_disk):
     issues = 0
 
     # 1. People appearing in more than one shard file (ambiguous / possible dup)
@@ -257,26 +229,6 @@ def run_check(index, manifest, files_on_disk, vault):
     for k in sorted(stale):
         print(f"    {k}  (region: {manifest[k]})")
     issues += len(stale)
-
-    # 4+5. Optional Person_Index drift (only if the file exists)
-    pi_names = read_person_index_names(vault)
-    if pi_names is None:
-        print("\n[4/5] Person_Index.md not present — skipping index drift check.")
-    else:
-        shard_names = set(index.keys())
-        shard_not_indexed = sorted(shard_names - pi_names)
-        indexed_not_in_shards = sorted(pi_names - shard_names)
-        print(f"\n[4] Shard people with no Person_Index row: {len(shard_not_indexed)}")
-        for n in shard_not_indexed[:40]:
-            print(f"    {n}")
-        if len(shard_not_indexed) > 40:
-            print(f"    ... and {len(shard_not_indexed) - 40} more")
-        print(f"\n[5] Person_Index names absent from every shard: {len(indexed_not_in_shards)}")
-        for n in indexed_not_in_shards[:40]:
-            print(f"    {n}")
-        if len(indexed_not_in_shards) > 40:
-            print(f"    ... and {len(indexed_not_in_shards) - 40} more")
-        # drift is advisory (name-matching is fuzzy); do not add to hard issues
 
     print(f"\n=== tree_locator --check: {issues} structural issue(s) "
           f"(dup-across-shards + manifest/disk mismatches) ===")

--- a/scripts/tree_locator.py
+++ b/scripts/tree_locator.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+tree_locator.py — derive a "which file is person X in?" locator from a sharded
+family tree, with NO hand-maintained index required.
+
+When `Family_Tree.md` outgrows a single file and is split into
+`Family_Tree_<Region>_<Branch>.md` shards, locating a person becomes a real
+problem. This tool answers it by reading the shards directly: it scans each
+`Family_Tree*.md` for bold-name narrative entries (`**Name** ( ... )`) and
+builds  name -> {file, generation, region}.
+
+- Region is OPTIONAL and comes from the File/Region manifest in Family_Tree.md
+  (see shard_manifest.py). Without a manifest, everything is one generic region.
+- Generation is read from the nearest `### Generation N` heading above an entry,
+  when the vault uses them; otherwise it is left blank.
+- Degrades gracefully: on an un-sharded vault it just reports a single file.
+
+Modes:
+  (default)    print the locator (name -> file [gen] [region]); summary counts
+  --by-file    group by shard file
+  --by-region  group by manifest region
+  --region X   filter to a region substring
+  --csv        emit CSV: name,file,generation,region
+  --check      integrity report (needs no index):
+                 * people appearing in >1 shard file (ambiguous / possible dup)
+                 * shard files on disk not declared in the manifest (no region)
+                 * manifest entries with no matching file on disk
+               and, only IF a Person_Index.md is present, an optional drift pass:
+                 * shard people with no Person_Index row
+                 * Person_Index names absent from every shard
+               --check exits 1 when any issue is found, else 0.
+
+Generic: contains no project-specific names. Pairs with shard_manifest.py as the
+"your vault outgrew one file" toolkit.
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+from collections import defaultdict
+
+import shard_manifest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_VAULT = os.path.join(os.path.dirname(SCRIPT_DIR), "vault")
+
+# Bold-name narrative entry header — same shape used across the audit suite:
+#   "**Full Name** ( ... )"  or  "**Full Name ( ... )**"
+# Require a proper-noun first token (Cap + lowercase) so all-caps labels
+# ("SECOND MARRIAGE", "FS-attached") are not mistaken for people.
+NAME_TOKEN_FIRST = r"[A-ZÀ-Ý][a-zà-ÿ][\w\.\-'À-ÿ]*"
+NAME_TOKEN_REST = r"[\w\.\-'À-ÿ]+"
+# Capture the parenthetical too (group 2) so we can confirm the entry is a person.
+HDR_A = re.compile(
+    rf"^[\-\*\s]*\*\*({NAME_TOKEN_FIRST}(?:\s+{NAME_TOKEN_REST}){{1,8}})\*\*\s*\(([^)]{{0,400}})",
+    re.MULTILINE,
+)
+HDR_B = re.compile(
+    rf"\*\*({NAME_TOKEN_FIRST}(?:\s+{NAME_TOKEN_REST}){{1,8}})\s*\(([^)]{{0,400}})"
+)
+GEN_HDR = re.compile(r"^#{1,4}\s+Generation\s+(\d+)", re.MULTILINE | re.IGNORECASE)
+
+# A real person entry's parenthetical carries a date signal (a year, or a
+# b./d./m./bapt marker). Bolded section labels and society/order names do not.
+DATE_SIGNAL = re.compile(r"\b\d{3,4}\b|\b[bdm]\.\s|\bborn\b|\bdied\b|\bbapt|\bc\.\s*\d", re.IGNORECASE)
+# A 4-digit number inside the NAME itself means it isn't a person name
+# ("Order of Three Crusades 1096-1192", "Researched 18 JUN 2026").
+NAME_HAS_YEAR = re.compile(r"\d{4}")
+# Lowercase tokens allowed inside a personal name (nobiliary particles /
+# connectors). Any OTHER lowercase token means the bold string is a label
+# ("Companion files", "In-law deep pedigrees"), not a person.
+NAME_CONNECTORS = {
+    "of", "de", "del", "della", "delle", "dei", "di", "da", "la", "le", "du",
+    "van", "von", "der", "den", "the", "e", "y", "d'", "dell'",
+}
+
+
+def _looks_like_name(name):
+    for tok in name.replace("-", " ").split():
+        t = tok.strip(".'")
+        if t and t[0].islower() and t.lower() not in NAME_CONNECTORS:
+            return False
+    return True
+
+
+def _is_person(name, paren):
+    """Heuristic person filter: name has no embedded year, reads like a personal
+    name (capitalized tokens + particles), and the parenthetical looks like a
+    vitals descriptor (carries a date signal)."""
+    return (not NAME_HAS_YEAR.search(name)
+            and _looks_like_name(name)
+            and bool(DATE_SIGNAL.search(paren)))
+
+
+def find_people(text):
+    """Yield (name, offset) for each bold-name PERSON entry (deduped by offset)."""
+    hits = []
+    for m in HDR_A.finditer(text):
+        if _is_person(m.group(1), m.group(2)):
+            hits.append((m.start(), m.group(1).strip()))
+    for m in HDR_B.finditer(text):
+        if _is_person(m.group(1), m.group(2)) and not any(abs(m.start() - o) < 10 for o, _ in hits):
+            hits.append((m.start(), m.group(1).strip()))
+    hits.sort()
+    seen = set()
+    for off, name in hits:
+        if off in seen:
+            continue
+        seen.add(off)
+        yield name, off
+
+
+def _gen_at(gens, offset):
+    """gens = sorted [(offset, gen)]; return gen of the last heading before offset."""
+    g = None
+    for o, n in gens:
+        if o <= offset:
+            g = n
+        else:
+            break
+    return g
+
+
+def build_index(vault):
+    """Return (index, manifest, files_on_disk).
+
+    index: name -> list of {file, gen, region} (one per shard the name appears in).
+    """
+    manifest = shard_manifest.load_shard_manifest(vault)
+    index = defaultdict(list)
+    files_on_disk = []
+    for path in sorted(glob.glob(os.path.join(vault, "Family_Tree*.md"))):
+        fn = os.path.basename(path)
+        files_on_disk.append(fn)
+        base = re.sub(r"\.md$", "", fn)
+        region = shard_manifest.region_for(base, manifest)
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        gens = [(m.start(), int(m.group(1))) for m in GEN_HDR.finditer(text)]
+        for name, off in find_people(text):
+            index[name].append({"file": fn, "gen": _gen_at(gens, off), "region": region})
+    return index, manifest, files_on_disk
+
+
+def _flat(index):
+    """Yield (name, file, gen, region) for every (name, shard) pair, sorted."""
+    rows = []
+    for name, locs in index.items():
+        for loc in locs:
+            rows.append((name, loc["file"], loc["gen"], loc["region"]))
+    rows.sort(key=lambda r: (r[3] or "", r[1], r[2] or 999, r[0]))
+    return rows
+
+
+# ----- lenient Person_Index parse (optional cross-check only) ----------------
+# Schema-tolerant: any markdown table row's FIRST cell is taken as the person
+# name. Does not assume a column count, so it works across index variants.
+_SEP_RE = re.compile(r"^\s*\|?[\s:\-|]+\|?\s*$")
+
+
+def read_person_index_names(vault):
+    """Return set of names from Person_Index.md, or None if the file is absent."""
+    path = os.path.join(vault, "Person_Index.md")
+    if not os.path.exists(path):
+        return None
+    names = set()
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            s = line.strip()
+            if not s.startswith("|") or _SEP_RE.match(line):
+                continue
+            first = s.strip("|").split("|", 1)[0].strip().strip("*").strip()
+            # skip the header row and empty cells
+            if not first or first.lower() in {"name", "person"}:
+                continue
+            names.add(first)
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Derive a person->shard-file locator from a sharded family tree.")
+    ap.add_argument("--vault", default=DEFAULT_VAULT, help="Path to the vault directory (default: ../vault).")
+    ap.add_argument("--by-file", action="store_true", help="Group output by shard file.")
+    ap.add_argument("--by-region", action="store_true", help="Group output by manifest region.")
+    ap.add_argument("--region", help="Filter to a region substring.")
+    ap.add_argument("--csv", action="store_true", help="Emit CSV: name,file,generation,region.")
+    ap.add_argument("--check", action="store_true", help="Integrity report; exit 1 if any issue.")
+    args = ap.parse_args()
+
+    index, manifest, files_on_disk = build_index(args.vault)
+
+    if args.check:
+        return run_check(index, manifest, files_on_disk, args.vault)
+
+    rows = _flat(index)
+    if args.region:
+        rows = [r for r in rows if r[3] and args.region.lower() in r[3].lower()]
+
+    if args.csv:
+        import csv
+        w = csv.writer(sys.stdout)
+        w.writerow(["name", "file", "generation", "region"])
+        for name, fn, gen, region in rows:
+            w.writerow([name, fn, gen if gen is not None else "", region])
+        return 0
+
+    if args.by_region or args.by_file:
+        key_idx = 3 if args.by_region else 1
+        groups = defaultdict(list)
+        for r in rows:
+            groups[r[key_idx]].append(r)
+        for key in sorted(groups):
+            print(f"\n== {key} ({len(groups[key])}) ==")
+            for name, fn, gen, region in groups[key]:
+                gtag = f"Gen {gen}" if gen is not None else "Gen ?"
+                extra = fn if args.by_region else region
+                print(f"  {gtag:<7} {name[:48]:<48} {extra}")
+    else:
+        for name, fn, gen, region in rows:
+            gtag = f"Gen {gen}" if gen is not None else "Gen ?"
+            print(f"  {gtag:<7} {name[:48]:<48} {fn}  [{region}]")
+
+    distinct = len(index)
+    print(f"\n{distinct} distinct people across {len(files_on_disk)} shard file(s); "
+          f"{len(rows)} name-in-file entries shown.")
+    return 0
+
+
+def run_check(index, manifest, files_on_disk, vault):
+    issues = 0
+
+    # 1. People appearing in more than one shard file (ambiguous / possible dup)
+    multi = {n: locs for n, locs in index.items() if len({l["file"] for l in locs}) > 1}
+    print(f"[1] People in >1 shard file: {len(multi)}")
+    for n in sorted(multi)[:40]:
+        print(f"    {n[:46]:<46} -> {', '.join(sorted({l['file'] for l in multi[n]}))}")
+    if len(multi) > 40:
+        print(f"    ... and {len(multi) - 40} more")
+    issues += len(multi)
+
+    # 2. Shard files on disk not declared in the manifest (so: no region)
+    declared = set(manifest.keys())
+    undeclared = [f for f in files_on_disk
+                  if re.sub(r"\.md$", "", f) != "Family_Tree"
+                  and not _declared(re.sub(r"\.md$", "", f), declared)]
+    print(f"\n[2] Shard files on disk NOT in the manifest (ungrouped): {len(undeclared)}")
+    for f in undeclared:
+        print(f"    {f}")
+    issues += len(undeclared)
+
+    # 3. Manifest entries with no matching file on disk (stale manifest rows)
+    on_disk_bases = {re.sub(r"\.md$", "", f) for f in files_on_disk}
+    stale = [k for k in declared if k not in on_disk_bases]
+    print(f"\n[3] Manifest entries with no file on disk (stale): {len(stale)}")
+    for k in sorted(stale):
+        print(f"    {k}  (region: {manifest[k]})")
+    issues += len(stale)
+
+    # 4+5. Optional Person_Index drift (only if the file exists)
+    pi_names = read_person_index_names(vault)
+    if pi_names is None:
+        print("\n[4/5] Person_Index.md not present — skipping index drift check.")
+    else:
+        shard_names = set(index.keys())
+        shard_not_indexed = sorted(shard_names - pi_names)
+        indexed_not_in_shards = sorted(pi_names - shard_names)
+        print(f"\n[4] Shard people with no Person_Index row: {len(shard_not_indexed)}")
+        for n in shard_not_indexed[:40]:
+            print(f"    {n}")
+        if len(shard_not_indexed) > 40:
+            print(f"    ... and {len(shard_not_indexed) - 40} more")
+        print(f"\n[5] Person_Index names absent from every shard: {len(indexed_not_in_shards)}")
+        for n in indexed_not_in_shards[:40]:
+            print(f"    {n}")
+        if len(indexed_not_in_shards) > 40:
+            print(f"    ... and {len(indexed_not_in_shards) - 40} more")
+        # drift is advisory (name-matching is fuzzy); do not add to hard issues
+
+    print(f"\n=== tree_locator --check: {issues} structural issue(s) "
+          f"(dup-across-shards + manifest/disk mismatches) ===")
+    return 1 if issues else 0
+
+
+def _declared(base, declared):
+    """True if `base` matches a manifest key by longest-prefix (mirrors region_for)."""
+    return any(base == k or base.startswith(k + "_") for k in declared)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vault-template/Family_Tree.md
+++ b/vault-template/Family_Tree.md
@@ -25,6 +25,18 @@ YOU (Living)
     └── [GRANDPARENT-4] (b. YYYY, d. YYYY)
 ```
 
+## Sharding & File Index
+
+A single `Family_Tree.md` is fine for a few hundred people. As a tree grows, keep this file to the recent core (e.g. Generations 1–N, plus this index) and split older or branch lineages into `Family_Tree_<Region>_<Branch>.md` shard files — one contiguous generation range per shard, grouped by geography or lineage. Delete this section if your tree is small enough to live in one file.
+
+The table below is both human navigation ("which file holds this branch?") and a machine-readable manifest. The **Region** column lets tooling group people by lineage: `scripts/shard_manifest.py` reads it, and `scripts/tree_locator.py` uses it to answer "which file is person X in?" by scanning the shards directly — no hand-maintained index required. A shard is matched to the longest `File` entry that is a prefix of its name, so a master row (`Family_Tree_Maternal`) automatically covers its children (`Family_Tree_Maternal_Highland`), while a more specific row overrides a broader one. Files not listed here fall back to a generic label.
+
+| File | Region | Content |
+|---|---|---|
+| [[Family_Tree_Paternal_Coastal]] | Coastal | [SURNAME-1], [SURNAME-2] ([place]; Gen 6–9) |
+| [[Family_Tree_Maternal_Highland]] | Highland | [SURNAME-3] ([place]; Gen 6–10) |
+| [[Family_Tree_Colonial_North]] | Colonial | [SURNAME-4], [SURNAME-5] ([place]; Gen 8–14) |
+
 ## [Paternal/Maternal] Line
 
 ### [SURNAME-1] Family


### PR DESCRIPTION
## What
Optional convention + tooling for trees that have outgrown a single `Family_Tree.md`.

- **Sharding manifest** — an optional `File | Region` table in `Family_Tree.md`
  (documented in `vault-template/Family_Tree.md`): declares which shard file holds
  which lineage/region.
- **`scripts/shard_manifest.py`** — reads that table; classifies a shard to a region by
  longest-prefix match (a master row covers its children); returns an empty map and
  falls back to a generic label when no manifest exists.
- **`scripts/tree_locator.py`** — answers "which file is person X in?" by scanning the
  shards directly (no hand-maintained index). Listing modes (`--by-file` / `--by-region`
  / `--csv`) plus `--check` (people in >1 shard, manifest↔disk coverage, and — only if a
  `Person_Index.md` is present — optional index drift).

## Why
Past a few hundred people, a single `Family_Tree.md` gets split by lineage — but then
"where did person X go?" has no answer. This derives the locator from the shards
themselves, so there is nothing extra to hand-maintain.

## Compatibility
Fully optional and additive. No manifest table → one generic region, locator still lists
people. Un-sharded vaults are unaffected. Both scripts are stdlib-only (`tree_locator`
imports `shard_manifest`).
