### PR TITLE
Enrich immigration, Jewish-genealogy, and colonial archive guides

### DIFF
--- a/archives/jewish-genealogy.md
+++ b/archives/jewish-genealogy.md
@@ -117,6 +117,15 @@ Jewish immigration to the Americas, South Africa, Palestine/Israel, and Australi
 
 Immigrant mutual aid societies organized by town of origin. Members who came from the same shtetl formed organizations that maintained membership rolls, cemetery sections, benefit records, and community newsletters. Many deposited their archives with YIVO Institute for Jewish Research in New York (https://www.yivo.org/). These records can identify individuals' towns of origin and connect immigrant families to their pre-migration communities.
 
+### Cemetery Records as Origin Clues
+
+Because those societies owned the cemetery plots, where a person is buried can reveal the family's town of origin:
+
+- **The society / section name points to the town.** Many large urban Jewish cemeteries publish searchable interment databases; the burial record's society or section field often names a hometown society (e.g. "First [Townname]er") that identifies the shtetl.
+- **Plot adjacency groups families.** Neighboring graves frequently identify spouses and disambiguate same-name individuals.
+- **Caveat:** a married woman was usually buried in her husband's society plot, so it indicates the household's (his) town, not necessarily her own birthplace.
+- **Hebrew headstones name the father.** The Hebrew inscription "[name] ben/bat [father's name]" gives the patronymic — recovering a generation for free, often corroborated by a firstborn child named for that ancestor.
+
 ## The Pale of Settlement
 
 From 1791 to 1917, most Jews in the Russian Empire were restricted to the Pale of Settlement: present-day Lithuania, Belarus, Ukraine, Moldova, and eastern Poland. Understanding the Pale is essential for Eastern European Jewish research because:
@@ -163,6 +172,7 @@ Sephardic and Mizrachi Jewish ancestry is harder to detect genetically because t
 ## Common Pitfalls
 
 - **Assuming all records were destroyed in the Holocaust.** Many survived in state archives, particularly in Lithuania, Ukraine, and Poland. Soviet-era archives preserved metric books as government property. JewishGen's databases index many of these surviving records.
+- **Conversely, confirm the records actually survive before an exhaustive hunt.** Some district registers genuinely were lost. Resources like Gesher Galicia's district inventories tell you whether a town's pre-war Jewish registers still exist; "town identified, records lost" is a valid, documentable endpoint — not a cue to keep re-searching a dead collection.
 - **Not using the Daitch-Mokotoff Soundex.** Standard Soundex was designed for English-language names and misses most Eastern European Jewish name variants. Always search with Daitch-Mokotoff, which is built into JewishGen's search tools.
 - **Overlooking Yizkor books.** These community memorial books are irreplaceable. If your ancestor's town has a Yizkor book, it may contain family names, photographs, and community history that survive nowhere else.
 - **Not distinguishing between Ashkenazi, Sephardic, and Mizrachi research.** These are fundamentally different research paths: different regions, different languages, different archives, different databases. JewishGen is strongest for Ashkenazi research. Sephardic research involves Iberian, Ottoman, and North African archives. Mizrachi research involves Middle Eastern and Central Asian archives.

--- a/archives/usa-colonial.md
+++ b/archives/usa-colonial.md
@@ -27,6 +27,7 @@ Colonial American records are fragmentary but certain record types survive well.
 ### Archive.org and Google Books
 - **Coverage**: Published county histories, genealogies, and compiled records
 - **Cost**: Free
+- **Note**: In-copyright digitized genealogies that aren't fully readable can often be **borrowed** through the Open Library (https://openlibrary.org) with a free account.
 - **AI accessibility**: AI-searchable and AI-readable
 
 ### DAR (Daughters of the American Revolution)
@@ -40,6 +41,14 @@ Colonial American records are fragmentary but certain record types survive well.
 - **Coverage**: Volunteer transcriptions of county records organized by state and county
 - **Cost**: Free
 - **AI accessibility**: AI-readable
+
+## Lineage Societies as Research Aids
+
+Hereditary societies vet and publish member lineages, which serve as compiled (secondary) sources — useful for orientation, but verify against primary records, since society applications sometimes perpetuate errors for decades.
+
+- **General Society of Mayflower Descendants (GSMD)**: the "Silver Books" (*Mayflower Families Through Five Generations*) document the first five generations of each Mayflower passenger's descendants — the standard starting point for Plymouth-colony Mayflower lines.
+- **DAR**: beyond the Patriot Index, the Genealogical Research System (GRS) links Revolutionary War patriots to documented descendant lineages.
+- **WikiTree project / Space pages** (e.g. the Mayflower project): free, sourced indexes into many of these society lineages — a quick way to locate a published line.
 
 ## Record Types by Survival Rate
 

--- a/archives/usa-immigration.md
+++ b/archives/usa-immigration.md
@@ -19,17 +19,33 @@ Immigration and naturalization records are among the most valuable sources for f
 - **Searchable**: Yes (by name, year, age, origin)
 - **AI accessibility**: AI-searchable
 
-### Castle Garden
-- **URL**: https://www.castlegarden.org/
-- **Coverage**: New York arrivals, 1820 to 1892 (~11 million records)
+### Castle Garden (pre-Ellis NY arrivals, 1820–1892)
+- **Status**: castlegarden.org has gone offline. The same New York arrivals (~11 million, 1820–1891) are now on **FamilySearch collection 1849782** ("New York Passenger Lists, 1820–1891"), the practical successor.
 - **Cost**: Free
-- **Searchable**: Yes
-- **AI accessibility**: AI-searchable
+- **Searchable**: Yes — search by name and filter on birth year/place; the arrival-date filter is unreliable.
 
 ### FamilySearch (Passenger Lists)
 - **Coverage**: Multiple US and Canadian ports
 - **Cost**: Free
 - **AI accessibility**: Browser-only for individual records
+
+### Steve Morse One-Step
+- **URL**: https://stevemorse.org/
+- **Coverage**: Free search front-ends for the major arrival databases — a "Gold Form" for Ellis Island (1892–1924, querying the JewishGen Enhanced Ellis Island Database) and a "White Form" (1820–1957)
+- **Cost**: Free
+- **Note**: Offers phonetic, missing-manifest, and town/companion filters that the native search interfaces lack; often finds arrivals a plain name search misses.
+
+### Internet Archive — NARA Microfilm Page Images
+- **URL**: https://archive.org/ (National Archives passenger-microfilm reels, uploaded one item per reel)
+- **Coverage**: The full New York arrival microfilm — M237 (1820–1897) and T715 (1897–1957) — as page images; the Internet Archive reel number matches the NARA roll number
+- **Cost**: Free
+- **Note**: Gives the actual manifest IMAGES, not just an index — essential when a name was never indexed and you must browse by ship and date. The film carries the same physical damage (torn or cut-off frames) as any other copy of that roll.
+
+### NARA Bulk Passenger Data Files
+- **URL**: https://catalog.archives.gov/ (downloadable passenger datasets, e.g. the Castle Garden / Balch series)
+- **Coverage**: Pipe-delimited text with origin-town, ship, arrival-date, and birthplace fields — searchable locally with ordinary text tools
+- **Cost**: Free
+- **Note**: Coverage is partial (weighted toward Russia and Austria-Hungary; sparse for Romania and post-1897), but useful for bulk searching when web indexes fail to surface a garbled name.
 
 ### What Passenger Lists Contain
 
@@ -40,6 +56,20 @@ Immigration and naturalization records are among the most valuable sources for f
 **Post-1906**: Added: personal description (height, complexion, hair, eyes), birthplace (city and country), name and address of nearest relative in country of origin, name and address of person joining in US, whether a polygamist, whether an anarchist, physical and mental health.
 
 **Post-1906 manifests are extremely valuable** because they list the specific city of birth in the old country, not just the country name.
+
+## Departure (Emigration) Records
+
+US arrival manifests were transcribed from passenger lists prepared at the port of *departure*. The departure-side record is often cleaner than the garbled arrival index and preserves the original European spelling of the name — use it to recover the correct name, then re-search the arrival manifest with it.
+
+- **Hamburg Auswandererlisten** (1850–1934): the primary departure port for Eastern and Central Europe; indexed on subscription sites.
+- **Bremen**: a major departure port, but most lists were destroyed.
+- **Antwerp / Red Star Line**: departures from Belgium.
+- **Stadsarchief Rotterdam** (https://stadsarchief.rotterdam.nl/passagierslijsten): Holland America Line departures from Rotterdam, 1900 onward — free and name-indexed; gives ship, departure date, and the European given name.
+- **Scandinavia**: Norway (Digitalarkivet) and Sweden (Emihamn / EmiWeb) maintain emigration indexes.
+
+### Arrivals Outside the US
+
+Not every emigrant went to the United States. For lines whose emigrants went to South America, **CEMLA** (https://search.cemla.com) indexes arrivals at Buenos Aires, Argentina, 1882–1960 (free).
 
 ## Naturalization Records
 
@@ -80,6 +110,13 @@ Immigration and naturalization records are among the most valuable sources for f
 5. Search for naturalization records in the county where your ancestor lived
 6. For post-1906, the naturalization petition is usually more informative than the passenger list
 7. Check Canadian border crossings if US ports yield no results
+
+### When a manifest can't be found
+
+- **A manifest line can be garbled or never indexed.** No name, Soundex, or ship search will reach it. Confirm the person's identity from an *independent* source first (a departure-side index, a naturalization petition, a headstone), then go to the manifest IMAGE knowing the ship and date to look for.
+- **Spouses often emigrated separately.** A wife frequently arrived on a different voyage under her maiden name. Search both surnames; don't assume a couple traveled together.
+- **Pre-1820 US passenger lists are sparse to nonexistent.** Federal passenger lists begin in 1820; earlier arrivals must be reconstructed from other records.
+- **A later vital record can name the birthplace the manifest omitted.** A death or marriage certificate from the destination city often names the immigrant's specific town of origin and parents — check the destination's vital-records archive when the manifest gives only a country.
 
 ## Name Variation Tips
 


### PR DESCRIPTION
## What
Enriches three existing archive guides with research resources and techniques.

**`archives/usa-immigration.md`**
- Corrects the **Castle Garden** entry — `castlegarden.org` is offline; the same 1820–1891 NY arrivals are on **FamilySearch collection 1849782**.
- Adds free resources: **Steve Morse One-Step**, **Internet Archive NARA microfilm page images** (M237/T715 manifest *images*), **NARA bulk passenger data files**.
- Adds a **Departure (Emigration) Records** section (Hamburg / Bremen / Antwerp / Rotterdam HAL / Scandinavia) — the departure side is often cleaner than the garbled arrival index — plus **CEMLA** for Argentine arrivals.
- Adds **"When a manifest can't be found"** techniques.

**`archives/jewish-genealogy.md`**
- Adds **"Cemetery Records as Origin Clues"** — landsmanshaft society/section = town, plot adjacency, married-woman caveat, Hebrew-headstone patronymics.
- Adds a pitfall: confirm a town's registers survive (e.g. Gesher Galicia district inventories) before an exhaustive hunt.

**`archives/usa-colonial.md`**
- Adds **"Lineage Societies as Research Aids"** — GSMD Silver Books (Mayflower), DAR GRS, WikiTree society Space pages, with the compiled-source caveat.
- Notes that in-copyright digitized genealogies can be **borrowed** via the Open Library.

## Notes
Generic reference content only — no project-specific tooling and no personal data. Independent of #13/#14.
