### PR TITLE
Fix validate-repo crash under non-UTF-8 locales

### DIFF
--- a/scripts/validate-repo
+++ b/scripts/validate-repo
@@ -6,6 +6,14 @@ require "digest"
 require "shellwords"
 require "yaml"
 
+# Prompt and archive files legitimately contain UTF-8 characters (em dashes,
+# arrows). Without this, File.read inherits the locale's default external
+# encoding, so under an ASCII locale (e.g. LANG unset or LANG=C) the first
+# String#match? against a non-ASCII byte raises
+# "invalid byte sequence in US-ASCII". Force UTF-8 so validation is
+# locale-independent.
+Encoding.default_external = Encoding::UTF_8
+
 ROOT = File.expand_path("..", __dir__)
 REQUIRED_PROMPT_FIELDS = %w[Goal Metric Direction Verify Guard Iterations Protocol].freeze
 REQUIRED_FRONTMATTER = %w[type created tags].freeze


### PR DESCRIPTION
## Problem

`scripts/validate-repo` aborts with a Ruby exception instead of validating when run under an ASCII locale (`LANG` unset, `LANG=C`, or `LC_ALL=C` — common in CI containers and minimal shells):

```
scripts/validate-repo:136:in `match?': invalid byte sequence in US-ASCII (ArgumentError)
	from scripts/validate-repo:133:in `check_prompts'
	from scripts/validate-repo:305:in `<main>'
```

`File.read` inherits the locale's default external encoding. Several prompt files legitimately contain UTF-8 characters, so under an ASCII locale the bytes come back tagged US-ASCII and the first `String#match?` against a non-ASCII byte raises `invalid byte sequence in US-ASCII`. The crash happens in `check_prompts` before any validation result is printed, so the validator is effectively unusable on those systems.

The non-ASCII content is intentional and correct (no mojibake) — just two characters:

| Codepoint | Char | Where |
|---|---|---|
| U+2192 `→` RIGHTWARDS ARROW | mapping notation | `prompts/05-source-citation-audit.md`, `06-unresolved-persons.md`, `09-bygdebok-extraction.md` (e.g. `Johannesen → Hansen`) |
| U+2014 `—` EM DASH | punctuation | `prompts/README.md` placeholder list |

## Fix

Set `Encoding.default_external = Encoding::UTF_8` at startup so every `File.read` decodes as UTF-8 regardless of locale. One line; no content changes.

## Verification

```
# before: crashes
LC_ALL=C ./scripts/validate-repo   →  invalid byte sequence in US-ASCII

# after: passes under both locales
LC_ALL=C            ./scripts/validate-repo   →  validate-repo: ok
LANG=en_US.UTF-8    ./scripts/validate-repo   →  validate-repo: ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)