### PR TITLE
Add source-citation-trace and onomastic-origins workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Before using public AI tools or sharing exports, follow [Privacy Mode](guides/pr
 
 ### Workflows (`workflows/`)
 
-8 step-by-step guides: getting started, OCR pipeline, image archive navigation, new ancestor intake, document triage, oral history protocol, discrepancy resolution, phase planning.
+10 step-by-step guides: getting started, OCR pipeline, image archive navigation, new ancestor intake, document triage, oral history protocol, discrepancy resolution, phase planning, source citation trace, onomastic origins.
 
 ### Examples (`examples/`)
 

--- a/workflows/onomastic-origins.md
+++ b/workflows/onomastic-origins.md
@@ -1,0 +1,55 @@
+# Onomastic Origins (surname → toponym → which archive holds the records)
+
+A repeatable method for building an **"Origins and Toponymy"** section for a surname lineage once the *primary-record* seam is exhausted and the remaining free leads are published history, onomastics, surname-distribution tooling, and archive-provenance lookups. It produces contextual analysis graded Strong / Moderate / Speculative **and**, as a side effect, tells you *which archive actually holds the named records* — so you stop chasing dead-end foreign archives and either find a digitized finding aid or draft a precise consultation request.
+
+## When to run this workflow
+
+Run it for a place/surname lineage when:
+
+1. **The free primary-record seam is worked.** Parish and civil registers for the wall era are exhausted, paid, or available in person only (deep walls often bottom out at pre-civil-registration parish books, in-person tax rolls, or diocesan archives).
+2. **You already hold a documented surname cluster** in one place, so etymology and distribution have an anchor to corroborate against.
+3. **You want either** (a) defensible contextual depth (etymology, regional history, the local naming system), **or** (b) to locate the archive that holds the named records and decide between a free finding aid and a paid or in-person request.
+
+Skip when the primary seam still has free, un-worked records (run those first), or when an Origins section already exists for that line (extend it, don't duplicate).
+
+## The five steps
+
+### Step 1 — Surname etymology and toponym
+Establish what the surname *means* and whether it encodes a place. Classify the naming **system**: toponymic, patronymic, occupational, nickname (soprannome / byname), gentry/territorial, or co-surname. Cross-check your own cluster: do the collateral surnames map to the same village's quarters and hamlets (toponymic), or to patronymics and nicknames? Tools: regional etymology dictionaries; the hamlet/contrada/townland list of the home place; published local history.
+
+### Step 2 — Regional and political history → which sovereign actually held the records
+Trace which state governed the place across the relevant centuries, because **that decides which archive holds the records** and prevents chasing dead-end foreign archives. Watch for the common trap where a territory was politically subject to one power but kept its records with the local or original administration — in that situation the records stay where they were created, and the records of the controlling power are a dead end. Output: a sovereign-by-era timeline ending in "→ records held at [archive]".
+
+### Step 3 — Surname-distribution mapping, with the spelling-split check
+Map the surname's modern geographic distribution to confirm a single localized origin, or to reveal multiple unrelated stocks of the same name. **Always map the native spelling separately from the emigrant spelling** — they routinely split (a space added or dropped, a consonant simplified, a diacritic lost on emigration), and a native and an anglicized form can resolve to entirely different regions. Tools:
+- **cognomix.it** — Italy, region and comune level (distribution data is in the page text; read it in a browser, not a plain fetch)
+- **nazwiska-polskie.pl** — Poland, locality level (JavaScript-rendered; needs a browser)
+- **forebears.io** — global and Great Britain
+- **GB1881 surname atlas** and UCL's **FaNUK** (Family Names of the United Kingdom) — British lines
+
+### Step 4 — Archive-provenance check → which archive holds the NAMED records, and its digitization status
+Find the specific archive, fonds, and unit that holds the records, and whether a finding aid or images are online. Tools:
+- **Italy**: Lombardia Beni Culturali (search the *complesso archivistico* and *conservatore/sede* fields), SIUSA (the unified archival-superintendency information system), and provincial state-archive finding aids
+- **Poland**: szukajwarchiwach, the AGAD/regional state-archive inventories, and metryki.genealodzy.pl
+- **United Kingdom**: TNA Discovery, county record-office catalogues, and family-history-society parish-register guides
+
+Output: archive + fonds + unit numbers + "free finding aid online? / images online? / in-person only?".
+
+### Step 5 — Draft a consultation request (only if documents are in-person or paid)
+If Step 4 lands on in-person or paid-reproduction documents, draft a concise consultation message naming the exact fonds and unit and the specific question (which named holders, which date span). Record the full text and the on-reply next steps. Sending it is a manual step for the researcher, not an autonomous action.
+
+## Confidence and scope discipline
+
+- Label every claim Strong / Moderate / Speculative, exactly as for primary-record work. Onomastic reasoning is corroboration, **not** a primary-source substitute — it can establish *that a surname is toponymic and indigenous to a place*, never *that person X descends from holder Y* without a record.
+- Place the result in the line's main family-tree file as a `## Origins and Toponymy: ...` section, with a "Researched [date] (web and regional-history pass; no new primary record)" disclaimer and a Sources list at the end.
+- Do **not** add person entries or identifiers from onomastic analysis — no individuals are identified by it. If you do name a specific dated individual in an Origins section, it must match that person's canonical entry elsewhere in the vault.
+
+## Tool notes
+
+- Some historical-gazetteer sites (for example, scanned 19th-century geographical dictionaries) return intermittent HTTP 500s — retry; they often carry per-village notes on noble, civil, and church status that bear directly on a gentry-vs-commoner question.
+- Surname-distribution sites are frequently JavaScript-rendered (cognomix.it serves its data as page text; nazwiska-polskie.pl renders client-side) — read them in a real or scriptable browser, not a plain HTTP fetch.
+- A plain fetch is fine for static history pages (encyclopedias, county-history sites) but fails on JavaScript-gated distribution sites and on some government and archive viewers (HTTP 403) — fall back to a browser for those.
+
+## Applying the method to Anglo lines
+
+The method works the same for British and colonial American surnames, which have unusually rich *free* tooling: forebears.io, the GB1881 surname atlas, UCL's FaNUK, the Guild of One-Name Studies, and the English Place-Name Society. For Scottish names, George F. Black's *The Surnames of Scotland* is the standard reference and resolves many multi-origin names that the lighter secondary sources leave open. As with the continental lines, treat the result as contextual corroboration and keep it clearly separated from primary-record claims.

--- a/workflows/source-citation-trace.md
+++ b/workflows/source-citation-trace.md
@@ -1,0 +1,112 @@
+# Source Citation Trace
+
+Before launching repeated gap-fill scans of archive registers (Antenati, FamilySearch image collections, Geneteka, etc.) for a known person, run this trace first. A single check often saves days or weeks of scanning by leading directly to the source image in an adjacent document bundle (a marriage-paperwork file, a baptism register, etc.) that contains the answer in one drill.
+
+The core idea: a community-tree profile frequently already links the exact register image you are about to spend hours hunting for. Contributors paste the direct archive link into the source citation. Check the citations before you scan.
+
+## When to run this workflow
+
+Always run before:
+- Launching an archive gap-fill scan across multiple years for one person's death/birth/marriage record
+- Launching a FamilySearch image-browse session across an unindexed collection
+- Opening any new research question of the form "person X's [event] is unknown, search [archive] [date range]"
+
+Skip this workflow when:
+- Your research log already records that the source citation was checked for this person
+- No community tree exists for the person (recent immigrant, brick-wall ancestor)
+- The trace was completed in a prior session (check your logs first)
+
+## The procedure
+
+### Step 1. Open the target person's community-tree profile
+
+Navigate to the person's FamilySearch profile at `https://www.familysearch.org/tree/person/details/[PID]`, where `[PID]` is the FamilySearch identifier.
+
+If the person has no FamilySearch profile, check other community trees (Geni, Ancestry, WikiTree) using the same logic. The "link to the original record" pattern exists on most community-tree platforms.
+
+### Step 2. Open the Sources tab and turn Detail View on
+
+The Sources tab sits between Details and Collaborate in the top tab strip. Switch to it.
+
+In Sources view, find the **Detail View** toggle on the left (next to "+ Add Source") and turn it on. This expands each source row to show all metadata fields, including the source URL. With Detail View off, the link-to-record field is not rendered, so you can miss a populated link entirely.
+
+### Step 3. Check each source for a "link to the record" field
+
+Expand each source row by clicking its title. In Detail View, each source shows:
+- **Tags** (Name, Birth, Death, etc.)
+- **Source Date** (when the original record was created)
+- **Web Page (Link to the Record)** — the key field
+- **Where the Record Is Found (Citation)** — the archive hierarchy
+- **Notes** — contributor notes about what the image contains
+
+The "link to the record" field, when populated, holds a direct URL to the source image. For records held by national digital archives this is typically a stable persistent identifier (for example, an Antenati ARK such as `https://antenati.cultura.gov.it/ark:/12657/.../...`).
+
+### Step 4. If a URL exists, follow it and drill the adjacent pages
+
+The source URL usually lands on one page inside a larger document bundle. In many civil-register systems, the most valuable bundle is the **marriage-paperwork file** (in the Italian system, the *processetti* or *allegati*) — a packet of certified extracts gathered to authorize one marriage. It can contain:
+- Both spouses' birth extracts
+- Death extracts for any deceased parents of the couple
+- Parental-consent documents (for living fathers, where required by the era)
+- The marriage banns
+- The marriage act itself
+
+These documents are grouped sequentially per couple. One such packet typically spans 5-15 pages.
+
+**Action**: use the archive's page viewer to move backward and forward from the linked page. Read each adjacent page until you exit the current packet (a new heading for the next couple signals the boundary). Transcribe the relevant details from each page in the packet — the answer to your question is often a few pages away from the linked one.
+
+### Step 5. Cross-reference findings against the open question
+
+Compare the new primary-source data against the hypothesis behind your planned gap-fill scan. Register paperwork frequently states a parent's living-or-deceased status directly (for example, Italian acts prefix a deceased person's name with "fu"). That single detail often resolves an alive/deceased question with no scanning at all.
+
+If the question is resolved, record it as resolved, write a log entry, and pivot the next search to whatever the new primary source points toward.
+
+### Step 6. If no URL exists, the trace concludes
+
+If no source has a populated link-to-record field, the trace is complete. Log "source-citation trace attempted, no linked image found," then proceed with the gap-fill scan as originally planned. The negative result is worth recording so a later session does not repeat the check.
+
+## Worked example (anonymized)
+
+A typical resolution follows this exact procedure:
+
+1. **Target**: the death record of a male ancestor born about 1770. Working hypothesis: he died in his home comune sometime in a ~35-year window.
+2. **Prior work**: roughly 1,200 negative register entries scanned across several sessions, with zero hits on the target — a classic sign the hypothesis or the date window is wrong.
+3. **Trigger**: a record turned up on the ancestor's *wife's* profile, prompting a citation check rather than yet another scan.
+4. **Trace**: wife's profile → Sources tab → Detail View on → expand the relevant source row.
+5. **Link to the record**: an archive ARK pointing to a specific page of a marriage-paperwork file from a year well *after* the assumed death window.
+6. **Notes field**: confirmed the page was a death extract included inside that later marriage packet.
+7. **Drill the adjacent pages**: the surrounding pages held the bride's birth extract, the linked death extract, the marriage notice, and the marriage act — and the act named the target ancestor as *present in person* to give consent, with no "deceased" prefix on his name.
+8. **Resolved**: the ancestor was demonstrably alive years past the window that had been scanned. The death search pivoted to the later period.
+
+The trace took about ten minutes from opening the profile to reading the decisive act. The earlier scans on the wrong window had consumed tens of hours.
+
+## Anti-pattern
+
+If you find yourself launching a **second** session of gap-fill scans for a person whose event date is still unknown, stop and run this trace. The cost of the trace is bounded (5-15 minutes); the cost of continuing a wrong-hypothesis scan is unbounded.
+
+## Handling downloaded register images
+
+Register pages from these archives are typically 3000-4500 px wide. A multimodal model downsizes large images internally before reasoning over them, but the full-resolution file is still transmitted on every read, so repeatedly reading one large page wastes bandwidth and can fail outright on request-size limits. Downsize once before reading:
+
+```bash
+sips -Z 1500 input.jpg --out /tmp/page-small.jpg          # macOS built-in
+# or, cross-platform with ImageMagick:
+magick input.jpg -resize 1500x page-small.jpg
+```
+
+To read one specific entry at full cursive detail without paying for the whole page, crop just that region instead of downsizing the page:
+
+```bash
+magick input.jpg -crop WxH+X+Y /tmp/entry.png             # +X+Y offset from top-left
+# optionally aid 19th-century cursive:
+magick input.jpg -crop WxH+X+Y -resize 180% -normalize -sharpen 0x1 /tmp/entry.png
+```
+
+Then read the small crop — full detail for the region of interest at a fraction of the payload. If you genuinely need full resolution across a whole page (for interactive locating), serve the file over a local HTTP server and zoom in a browser rather than reading the full-resolution file directly, which keeps the large image out of the model's context entirely.
+
+After the session, triage the downloaded images: move pages that became part of a vault entry into your images directory, and delete exploratory-only pages.
+
+## See also
+
+- `reference/common-pitfalls.md` — Search Strategy Pitfalls
+- `workflows/discrepancy-resolution.md` — for conflicts between a citation-linked source and gap-fill findings
+- `workflows/image-archive-navigation.md` — driving archive image viewers


### PR DESCRIPTION
Two methodology workflows that fill gaps the existing eight do not cover.

## `workflows/source-citation-trace.md`
Before launching multi-year register gap-fill scans for a person, check the community-tree source citations first. A populated "Web Page (Link to the Record)" field on a FamilySearch (or Geni/Ancestry/WikiTree) profile often points straight at the register image — frequently inside an adjacent marriage-paperwork bundle (the Italian *processetti*/*allegati*) that holds the certified birth/death extracts resolving the question in one drill. This turns a tens-of-hours scan into a roughly ten-minute trace. Includes the Detail-View gotcha (the link field is not rendered with Detail View off), an anonymized worked example, and a cross-platform image-downsizing/cropping note for reading large register pages economically.

## `workflows/onomastic-origins.md`
A five-step method for building an "Origins and Toponymy" section once the free primary-record seam is exhausted: surname etymology -> sovereign history (which state's archive actually holds the records) -> distribution mapping with a native-vs-emigrant spelling-split check -> archive-provenance lookup -> consultation request. Names concrete free tooling (cognomix.it, nazwiska-polskie.pl, forebears.io, GB1881, UCL FaNUK, Lombardia Beni Culturali, SIUSA, szukajwarchiwach, TNA Discovery) and, as a side effect, identifies which archive holds the records so you stop chasing dead-end foreign archives.

Both grade claims Strong / Moderate / Speculative and keep onomastic/contextual reasoning clearly separated from primary-source claims, consistent with the existing reference material.

Also updates the README workflow count (8 -> 10). `scripts/validate-repo` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)