### PR TITLE
Fix privacy-audit-repo crash under non-UTF-8 locales (companion to #17)

### DIFF
--- a/scripts/privacy-audit-repo
+++ b/scripts/privacy-audit-repo
@@ -7,6 +7,14 @@ require "digest"
 require "shellwords"
 require "time"
 
+# Denylist terms and tracked files legitimately contain UTF-8 characters (accented
+# names, diacritics). Without this, Shellwords#shelljoin (building the `git log
+# -S<term>` history query) and File.read inherit the locale's default external
+# encoding, so under an ASCII locale (e.g. LANG unset or LANG=C) the first
+# non-ASCII byte raises "invalid byte sequence in US-ASCII". Force UTF-8 so the
+# audit is locale-independent. (Companion to the same fix in validate-repo, #17.)
+Encoding.default_external = Encoding::UTF_8
+
 ROOT = File.expand_path("..", __dir__)
 DENYLIST_PATH = File.join(ROOT, ".private/anonymization-denylist.txt")
 DEFAULT_REPORT_DIR = File.join(Dir.home, ".cache", "autoresearch-genealogy", "privacy-audits")


### PR DESCRIPTION
## Summary

#17 fixed a `Shellwords#shelljoin` / `File.read` encoding crash in `validate-repo`, but its sibling `scripts/privacy-audit-repo` carries the identical bug and was overlooked by that PR.

Denylist terms and tracked files legitimately contain UTF-8 characters (accented names, diacritics such as `Szelków` / `Kadzidło`). Without a forced encoding, `Shellwords#shelljoin` (building the `git log -S<term>` history query) and `File.read` inherit the locale's default external encoding, so under an ASCII locale (`LANG` unset or `LANG=C`) the first non-ASCII byte raises `invalid byte sequence in US-ASCII` and the audit crashes before producing a report.

## Fix

One line, mirroring #17:

```ruby
Encoding.default_external = Encoding::UTF_8
```

## Verification

- Before: crashes with `invalid byte sequence in US-ASCII` when the denylist contains a diacritic term under `LANG=C LC_ALL=C`.
- After: runs clean (exit 0) under `LANG=C LC_ALL=C` with no `RUBYOPT`/locale workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)