### PR TITLE
Add download-validation, source-citation check, and NYC vital records guidance

### DIFF
--- a/archives/usa-vital-records.md
+++ b/archives/usa-vital-records.md
@@ -48,6 +48,14 @@ For records predating state registration, the county clerk or recorder of deeds 
 - **Cost**: Varies ($5 to $25 per record)
 - **AI accessibility**: In-person, phone, or mail request
 
+### NYC Historical Vital Records (NYC Municipal Archives / DORIS)
+- **URL**: https://a860-historicalvitalrecords.nyc.gov
+- **Coverage**: ~13.3 million NYC **birth, death, and marriage** certificate IMAGES (78% digitized as of 19 JUN 2026), all five boroughs (Kings/Brooklyn, Bronx, Manhattan, Queens, Richmond/Staten Island). Typical public ranges: **births to ~1909, marriages to ~1949, deaths to ~1948** (rolling; recent years restricted).
+- **Cost**: **Free** — full certificate images viewable AND downloadable, no account required.
+- **Search**: by **Last Name** (+ certificate type + borough + year) OR directly by **Certificate Number** (if known from a FamilySearch index or another cert). Browse mode also available by type/borough/year.
+- **AI accessibility**: **Browser-only** (DORIS image viewer; WebFetch returns 503). Drive it in a browser; download the certificate JPG/PDF, then read the image with your AI tool.
+- **Why it matters**: these are the *actual certificate images*, which carry data the FamilySearch *index* omits — e.g. **mother's maiden name on a birth cert**, **the deceased's parents on a death cert**. This is the source that resolves NYC maiden-name disputes and breaks Gen-5 brick walls on NYC immigrant-family lines. Pair it with the FamilySearch index (which gives the certificate number to look up here).
+
 ## Record Types
 
 ### Birth Certificates

--- a/reference/common-pitfalls.md
+++ b/reference/common-pitfalls.md
@@ -73,3 +73,14 @@ Every person in your tree should have at least two independent sources. A person
 
 ### Ignoring Discrepancies
 When two sources disagree, do not quietly pick one. Document both, note which is more reliable and why, and mark the discrepancy for future resolution. Silent choices become invisible errors.
+
+## Search Strategy Pitfalls
+
+### Skipping the FS Source Citation Check Before Gap-Fill Scans
+When a person's death date (or other event) is unknown, the instinct is to launch register scans across a plausible date window: 1816, 1817, 1818, ... year by year. This can burn days or weeks of scanning if the underlying hypothesis is wrong.
+
+Before launching any gap-fill scan of a known archive (Antenati ARKs, FamilySearch image collections), open the target person's FamilySearch profile (or other community-tree profile), open the Sources tab, toggle Detail View on, and check each attached source for a "Web Page (Link to the Record)" field. Community contributors often paste the direct archive URL to the source image. That image is often part of an adjacent fascicolo (e.g., an Italian matrimoni processetti bundle containing certified extracts of birth, death, and consent records for both spouses and their parents) — drilling 5-10 adjacent pages may surface documents that resolve the question in one pass.
+
+This single check takes minutes; skipping it can cost weeks of scans on the wrong hypothesis. Worked example: one Italian ancestor (b. ~1770) accumulated roughly 1,200 negative *atti* scans across an 1816-1850 death-register window before a single FS source-citation trace on his wife's profile led straight to an 1852 *matrimoni processetti* page proving him still alive at age 82 — the death-window hypothesis had been off by decades.
+
+The pattern generalizes to any record system where contributors attach source images to person profiles: Antenati (via FamilySearch), Geneteka (Polish), ScotlandsPeople (Scottish), etc. Always trace a person's existing source citations before launching a fresh register scan.

--- a/workflows/ocr-pipeline.md
+++ b/workflows/ocr-pipeline.md
@@ -46,6 +46,42 @@ Sort every scanned file into one of four categories:
 | **Mixed** | Postcards (printed front, handwritten back), annotated documents | Layered: Tesseract for printed portions, Claude for handwritten |
 | **Photo only** | Portraits, group photos, buildings, landscapes | No OCR; catalog metadata only |
 
+## Stage 2.5: Validate (always, before any processing)
+
+Network downloads can return error pages (HTML, JSON error blobs, Cloudflare challenge pages) with a `.jpg` extension. These are typically a few KB of ASCII text. Running `sips`, `tesseract`, or the multimodal `Read` tool on such a file produces cryptic errors or silently bad output, and any "OCR negative" finding from such a batch is unreliable. Validate every image before processing.
+
+**Single-file check** (returns just the MIME type; `image/jpeg` means valid):
+
+```bash
+file --mime-type -b path/to/image.jpg
+```
+
+**Batch validation** (lists every file in a directory that is NOT a real JPEG, with its size):
+
+```bash
+for f in path/to/dir/*.jpg; do
+  mime=$(file --mime-type -b "$f")
+  if [ "$mime" != "image/jpeg" ]; then
+    echo "INVALID: $f ($mime, $(wc -c < "$f") bytes)"
+  fi
+done
+```
+
+If the batch validator produces no output, every file is a real JPEG and processing can proceed. Any line of output is a file that must be re-downloaded (or deleted) before continuing — do NOT attempt to crop, OCR, or visually read it.
+
+**Quick alternative** (faster to type, slightly noisier output):
+
+```bash
+file path/to/dir/*.jpg | grep -v "JPEG image data"
+```
+
+**Size sanity** (complement to magic-byte check). For known image sources, a too-small file is almost always a failed download:
+- Antenati IIIF at `full/1723,/0/default.jpg` → expect 150-300 KB per page
+- FamilySearch DeepZoom tile downloads → expect 100-500 KB per page
+- A file under ~10 KB labeled `.jpg` is almost always an error page or partial body
+
+Apply this step to every batch download before moving on to Stage 3.
+
 ## Stage 3: OCR and Transcribe
 
 ### Printed Text (Tesseract)


### PR DESCRIPTION
## Summary

Three generic, self-contained methodology additions, drawn from real research use:

- **`workflows/ocr-pipeline.md`** — a **Stage 2.5: Validate** step. Network downloads sometimes return HTML/JSON error pages (Cloudflare challenges, 503s) with a `.jpg` extension; running OCR on them yields silent garbage and false "OCR negative" findings. Adds magic-byte (`file --mime-type`) + size-sanity checks to run before any processing.
- **`reference/common-pitfalls.md`** — a **Search Strategy Pitfalls** section: trace a person's existing source citations (FamilySearch Sources tab → Detail View → "Web Page (Link to the Record)") before launching a gap-fill register scan. Contributors often attach the direct archive image, which can resolve the question in one drill instead of weeks of year-by-year scanning.
- **`archives/usa-vital-records.md`** — the **NYC Historical Vital Records / DORIS** portal (free birth/death/marriage certificate *images*, all five boroughs) that carry mother's-maiden-name and parents the FamilySearch *index* omits.

All three are model-agnostic (no assumptions about vault structure) and self-contained (no new cross-file dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)