### PR TITLE
Enrich immigration-search and tree-expansion prompts

### DIFF
--- a/prompts/01-tree-expansion.md
+++ b/prompts/01-tree-expansion.md
@@ -14,36 +14,42 @@ Find source-backed candidate relationships for deceased ancestors without treati
 - `[LOCATION]`: relevant town, county, state, province, or country
 - `[BIRTH YEAR]`: known or approximate birth year
 - `[SURNAME]`: family surname or historical surname variant
+- `[FS_GROUP_TREE]`: URL of your FamilySearch group/family tree, if you use one (configure in your local project instructions)
+- `[SUBJECT_PID]`: the starting person's FamilySearch PID (configure in your local project instructions)
+- `[SCOPE]` (optional): a subset of shard files / a Region to focus on; leave unset to expand the whole tree
 
 ## Autoresearch Configuration
 
-**Goal**: For each deceased, source-suitable ancestor currently in `[VAULT_PATH]/Family_Tree.md`, search for source-backed parent, sibling, spouse-family, or earlier-generation leads. Update the vault only when the evidence tier is clear. Keep speculative leads separate from confirmed relationships.
+**Goal**: For each deceased, source-suitable ancestor currently in the Family Tree files (`[VAULT_PATH]/Family_Tree.md` and the shard files listed in its File Index), search for source-backed parent, sibling, spouse-family, or earlier-generation leads. Update the vault only when the evidence tier is clear, and keep speculative leads separate from confirmed relationships. Keep iterating until no more ancestors can be found through free web sources or your FamilySearch group tree `[FS_GROUP_TREE]` (read-only via a logged-in browser session).
 
-**Metric**: Number of source-backed candidate relationships reviewed and classified as `strong_signal`, `moderate_signal`, `speculative`, or rejected
+**Metric**: Number of new ancestors/individuals added across all Family Tree files, and the number of source-backed candidate relationships reviewed and classified as `strong_signal`, `moderate_signal`, `speculative`, or rejected
 
 **Direction**: Maximize reviewed, source-backed classifications. Do not maximize raw person count.
 
-**Verify**: In `[VAULT_PATH]/Research_Log.md`, count this iteration's reviewed candidate relationships by tier: strong, moderate, speculative, rejected, and not searched because privacy blocked it.
+**Verify**: Count the number of named individuals across all Family Tree files before and after each iteration and log the delta. In `[VAULT_PATH]/Research_Log.md`, also count this iteration's reviewed candidate relationships by tier: strong, moderate, speculative, rejected, and not searched because privacy blocked it.
 
 **Guard**:
+- **Scope (optional)**: to focus on a subset rather than the whole tree, set `[SCOPE]` to the shard files / Region you're targeting and limit every step to those; log incidental out-of-scope finds to `Open_Questions.md` for a future run.
 - Do not fabricate ancestors. Every addition must cite a source.
 - Do not trust user-contributed trees (Geni, Ancestry hints) without corroboration from at least one independent source.
 - Do not add a confirmed parent-child relationship from a user-contributed tree alone. Treat it as a lead.
-- Do not modify existing dates or names during expansion; that is the cross-reference audit's job.
-- Mark any unverified additions with `(speculative)` or `evidence_tier: speculative`.
-- Prefer adding a lead to `Open_Questions.md` over adding a weak ancestor to `Family_Tree.md`.
+- Do not modify existing dates or names during expansion; that is the cross-reference audit's job (`02-cross-reference-audit`).
+- Mark any unverified additions with `(speculative)` or `evidence_tier: speculative` in the tree.
+- Prefer adding a lead to `Open_Questions.md` over adding a weak ancestor to a Family Tree file.
 - Do not run web searches on living people. Treat the starting person, their siblings, parents, and any person without a death date as living unless the vault clearly states otherwise.
 - Do not publish exact birth dates, addresses, or contact details for living or possibly living people. Use birth year only, or mark as `Living`.
+- **Scope boundary — discovery only, no FS contribution.** Use the FamilySearch group tree **read-only** as a discovery source. Do NOT perform FamilySearch mutations (Add Person / Attach Source / Add Relationship) here — this prompt is read-only discovery. Pushing vault-confirmed persons UP into FamilySearch and recording their PIDs is a separate, operator-gated step; the persons this prompt adds to your tree (not yet linked to FamilySearch) become that step's candidate list.
 
-**Iterations**: 8
+**Iterations**: 15
 
 **Protocol**:
 
-1. **Baseline**: Read `[VAULT_PATH]/Family_Tree.md` completely. Record the starting source posture in `[VAULT_PATH]/Research_Log.md`: known deceased targets, living or privacy-blocked people skipped, already sourced relationships, and known speculative relationships.
+1. **Baseline**: Read all Family Tree files completely. Count every named individual across all files, and record the starting source posture in your research log: the baseline count, known deceased targets, living or privacy-blocked people skipped, already sourced relationships, and known speculative relationships.
 
 2. **Identify expansion targets**: For each leaf node (an ancestor with no listed parents), note:
    - Name, dates, and location
    - Which web sources might have their parents (Find a Grave, Geni, WikiTree, FamilySearch wiki, published county histories)
+   - **Before searching**: check your research logs and `Open_Questions.md` for the ancestor's name to see what has already been tried. Do not repeat searches that returned negative results in prior sessions unless you have a new source, spelling variant, or search strategy not previously attempted.
 
 3. **Search strategy per ancestor**: For each target, run web searches in this order:
    a. `"Find a Grave" "[ANCESTOR NAME]" [DEATH YEAR] [BURIAL LOCATION]`
@@ -52,29 +58,48 @@ Find source-backed candidate relationships for deceased ancestors without treati
    d. `site:wikitree.com "[ANCESTOR NAME]"`
    e. `"[ANCESTOR NAME]" genealogy [LOCATION] [SURNAME]`
 
-4. **Evaluate results**: For each search hit:
+4. **Additional search strategies**: For any line that originates outside your home country, consult the relevant archive guide in `archives/` for country-specific databases, access methods, and AI accessibility notes before searching that line.
+
+   **Country-specific archive guides** (read the relevant guide before searching that country's records):
+   a. **Italian ancestors**: Read `archives/italy.md` for a full list of Italian genealogical databases. Key resources: Antenati portal (https://antenati.cultura.gov.it/?lang=en) for civil registration; FamilySearch Italian collections (partially indexed, partially browse-only); diocesan archives for pre-1809 parish records. Note: Antenati coverage varies by province (some provinces have limited digitization).
+   b. **Polish ancestors**: Read `archives/poland.md`. Key resources: Geneteka (https://geneteka.genealodzy.pl) for indexed vital record transcriptions; Szukaj w Archiwach (https://szukajwarchiwach.gov.pl) for digitized images; FamilySearch Polish collections. Note: many smaller rural parish records (especially outside the larger provincial towns) are not digitized online.
+   c. **English/Welsh ancestors**: Read `archives/england-wales.md`. Key resources: FreeBMD (https://www.freebmd.org.uk) for civil registration indexes from 1837; FreeREG for parish register transcriptions; GENUKI (https://www.genuki.org.uk/big) for county-level guides; GRO certificates (~11 GBP each).
+   d. **Scottish ancestors**: Read `archives/scotland.md`. Key resources: ScotlandsPeople (https://www.scotlandspeople.gov.uk) for OPR, civil registration, and census; NRS (National Records of Scotland).
+   e. **Irish ancestors**: Read `archives/ireland.md`. Key resources: IrishGenealogy.ie for civil registration; NLI Catholic Parish Registers; Griffith's Valuation.
+   f. **Colonial American ancestors**: Read `archives/usa-colonial.md` for pre-1800 records; `archives/usa-vital-records.md` for state vital records; `archives/usa-immigration.md` for immigration/naturalization. Key resources: FamilySearch, Internet Archive (digitized genealogies), DAR GRS.
+   g. **USA Census records**: Read `archives/usa-census.md` for census research strategies across all decades.
+
+   **Cross-cutting resources** (useful for all lines):
+   h. FamilySearch signed-in access: use your group tree `[FS_GROUP_TREE]` via a logged-in browser session (read-only)
+   i. Internet Archive / Open Library (https://archive.org, https://openlibrary.org): digitized genealogies, county histories, and GSMD Silver Books available for borrowing. Ask to log in to borrow books.
+   j. Cyndi's List (https://www.cyndislist.com/categories/): comprehensive categorized genealogy link directory
+   k. WikiTree (https://www.wikitree.com): collaborative genealogy with sourcing requirements; search by surname or use Space pages for Mayflower, DAR, etc.
+   l. Find a Grave (https://www.findagrave.com): cemetery records with photographs; particularly useful for confirming death dates and family groupings
+
+5. **Evaluate results**: For each search hit:
    - Does the person match on name, dates, AND location? All three must align.
    - Is the source a primary record (vital record, church register) or secondary (user tree, published genealogy)?
    - If secondary, does at least one other independent source corroborate?
    - Could another same-name person explain the record?
    - What evidence tier does the candidate relationship deserve?
 
-5. **Update the vault**: For each reviewed candidate:
-   - Add `strong_signal` or `moderate_signal` relationships to Family_Tree.md in the correct position with citations
-   - Add weak or single-source relationships to `Open_Questions.md`, not as confirmed tree facts
-   - If sufficient data exists, create a person file using the template at `[VAULT_PATH]/templates/person.md`
-   - Note the source in the person file's Document Sources section
+6. **Update the vault**: For each reviewed candidate:
+   - Add `strong_signal` or `moderate_signal` relationships to the appropriate Family Tree shard in the correct position, with citations — route each person to the shard whose Region/scope matches their line (see the File Index in `Family_Tree.md`).
+   - Add weak or single-source relationships to `Open_Questions.md`, not as confirmed tree facts.
+   - Record each new person in your tree following your project's conventions (a unique id, evidence tier, and generation), with a source citation for every fact.
+   - Cite each new fact where you record it (source-first); include any FamilySearch record ARKs that support the person.
 
-6. **Log the search**: In `[VAULT_PATH]/Research_Log.md`, record:
+7. **Log the search**: Record the session in your research log:
    - Date and search target
    - Queries used
    - Results (positive or negative)
    - Candidate relationships reviewed, accepted, rejected, or held as speculative
    - What remains unresolved
+   Then add a one-line summary entry to your research log's session index.
 
-7. **Update the classification table**: After each iteration, report counts for strong, moderate, speculative, rejected, and privacy-blocked candidates. If the tree grew but source quality did not, treat the iteration as a failure.
+8. **Update the count and classification**: After each iteration, recount named individuals across all Family Tree files and report the delta. Also report counts for strong, moderate, speculative, rejected, and privacy-blocked candidates. If the tree grew but source quality did not, treat the iteration as a failure.
 
-8. **Repeat**: Move to the next set of expansion targets. Prioritize:
+9. **Repeat**: Move to the next set of expansion targets. Prioritize:
    - Lines with the fewest known generations (shallowest branches)
    - Ancestors with specific dates and locations (higher probability of finding records)
    - Lines with no person files yet (lowest current documentation)
@@ -85,3 +110,4 @@ Find source-backed candidate relationships for deceased ancestors without treati
 - **Name changes at immigration**: Many immigrants changed or simplified their names. Search both the original and Americanized versions.
 - **Negative results matter**: If you search for an ancestor and find nothing, log it. This prevents duplicate searches later.
 - **Sibling research**: Sometimes the easiest way to find an ancestor's parents is to find their siblings first. Siblings often appear in more records.
+- **FamilySearch** : Use the signed-in FamilySearch capability and your group tree `[FS_GROUP_TREE]` (starting person `[SUBJECT_PID]`) **as a read-only discovery source** (browse it for ancestors/relationships to add to your tree). Contributing back to FS and recording PIDs is a separate, operator-gated step.

--- a/prompts/11-immigration-search.md
+++ b/prompts/11-immigration-search.md
@@ -1,6 +1,6 @@
 # Immigration Search
 
-Search for immigration, naturalization, and passenger records for immigrant ancestors.
+Search for immigration, naturalization, emigration, and passenger records for immigrant ancestors.
 
 > **Sharded trees (optional):** if your `Family_Tree.md` has grown and been split into shard files (listed in its File Index — see `vault-template/Family_Tree.md`), treat every reference to `Family_Tree.md` in this prompt as also covering those shard files: read them all, and route new people to the shard whose Region matches their line. Un-sharded vaults can ignore this note.
 
@@ -14,69 +14,106 @@ Search for immigration, naturalization, and passenger records for immigrant ance
 
 ## Autoresearch Configuration
 
-**Goal**: For every immigrant ancestor in `[VAULT_PATH]/Family_Tree.md`, locate their immigration record (passenger manifest), naturalization record, or both.
+**Goal**: For every immigrant ancestor in the regional family-tree files (`[VAULT_PATH]/Family_Tree.md` and the shard files in its File Index), locate their immigration record (passenger manifest), emigration record (departure-side index), and/or naturalization record.
 
-**Metric**: Number of immigrant ancestors without an immigration or naturalization record
+**Metric**: Number of immigrant ancestors without an immigration, emigration, or naturalization record
 
 **Direction**: Minimize (lower is better)
 
-**Verify**: Count immigrant ancestors in Family_Tree.md who lack citation to a passenger list or naturalization document.
+**Verify**: Count immigrant ancestors (born outside the US, with "emigrated"/"immigrated" notation) across the family-tree files who lack a citation to a passenger list, departure-side index, or naturalization document.
 
 **Guard**:
-- Name spelling on passenger manifests can be extremely different from what the family used in America. Search all plausible variants.
+- Name spelling on passenger manifests can be extremely different from what the family used in America. Search all plausible variants, including the **original-language / European spelling** (see techniques below).
 - Not all immigrants were naturalized. Some remained resident aliens their entire lives.
-- Pre-1820 US passenger lists are sparse to nonexistent.
+- Pre-1820 US passenger lists are sparse to nonexistent. Pre-1892 NY arrivals are Castle Garden, not Ellis Island.
+- **A US arrival manifest line can be garbled or never-indexed** (no name/soundex/ship/first-name search reaches it). Confirm the identity from an independent source (departure-side index, naturalization, headstone) FIRST, then go to the manifest IMAGE knowing what to look for.
+- **Spouses frequently emigrated separately.** A wife often arrived under her maiden name on a different voyage. Search both surnames and don't assume a couple travelled together.
+- **Common immigrant names need disambiguation, not just a name match.** A common immigrant name returns many same-name men. Distinguish by birthplace, census ward / household composition, spouse + children's names, and age→birth-year BEFORE attaching a record, adopting a PID, or merging a profile. (a same-name man with a different birthplace, spouse, or census ward is NOT a merge — post an FS Alert Note instead of merging.)
+- **Couples who married in Europe leave no US marriage record** naming their parents. If the index shows no shared certificate number between a groom's certs and a bride's certs, they married pre-immigration — the parents (Gen +1) are then only on European records or a US death/naturalization image.
+- **Distinguish free (Claude-drivable) work from operator-gated work** and label each finding accordingly. Index/database SEARCHES are free; downloading record IMAGES, captcha-gated archive searches, and ordering certificates are operator steps. Do not re-propose an operator-gated item as a free next-action.
+- **CREATE/edit actions on FamilySearch are operator-gated.** This prompt is discovery + writing findings back to your own tree; pushing anything up to FamilySearch is a separate, human-approved step.
 
 **Iterations**: 10
 
 **Protocol**:
 
-1. **Identify immigrant ancestors**: From Family_Tree.md, list every person born outside the US (or with "emigrated" / "immigrated" notation). For each, note:
-   - Name (all known variants, including original language spelling)
-   - Approximate arrival year or range
-   - Country of origin (as specific as possible: country, region, city/village)
-   - Port of entry (if known)
-   - Final destination in the US
+1. **Identify immigrant ancestors**: From each family-tree file, list every person born outside the US (or with "emigrated"/"immigrated" notation). Before searching, **check your research logs and open-questions notes for the name** to see what has already been tried (do not repeat prior negative searches unless using a new source or strategy). For each immigrant, note:
+   - Name (all known variants, including original-language and Hebrew/Yiddish spelling)
+   - Approximate arrival year or range; approximate emigration year
+   - Country/region of origin (as specific as possible: country, region, province, town/shtetl)
+   - Port of departure and port of entry (if known); ship name (if known)
+   - Final destination in the US; who they were joining
 
-2. **Search passenger manifests**:
-   a. `site:ellisisland.org "[ANCESTOR NAME]"` (covers 1892 to 1957 for New York)
-   b. `"[ANCESTOR NAME]" passenger manifest [YEAR RANGE]`
-   c. FamilySearch: search the relevant port's passenger list collection
-   d. Try name variants: original spelling, phonetic spellings, abbreviated names, maiden name (for women)
-   e. If name searches fail, try searching by ship name (if known from family records) + approximate date
+2. **Search arrival (US) passenger manifests** (NY = Ellis Island 1892+; Castle Garden / Barge Office pre-1892):
+   a. **Steve Morse One-Step** (stevemorse.org) — the best free front-end. The **Gold Form (1892–1924)** searches the JewishGen Enhanced Ellis Island DB (a logged-in JewishGen session carries via cookies) with Daitch-Mokotoff phonetic surname + arrival-year-range + age-range + gender + town + companion filters. **Driving gotcha:** the form is GET with `target=_blank` (a synthetic submit just opens a blocked popup → nothing happens); instead serialize the form fields to a query string and navigate to `action?query` in-tab (then mutate `LNM`/`SYR`/etc. on the URL for follow-up searches). The **White Form** covers 1820–1957. (`ellisgold.html` 404s — reach the live forms from the stevemorse.org homepage.)
+   b. **FamilySearch** passenger collections: pre-1892 NY = collection **`1849782`** ("New York Passenger Lists, 1820-1891" — the successor to the now-**DEFUNCT** castlegarden.org), Ellis 1892+ = a separate FS collection. Search by name variant + birth-year + birthplace (the FS arrival-date URL params error — filter on birth year/place instead). FS Soundex over-matches (a Soundex search pulls unrelated like-sounding surnames).
+   c. **Internet Archive — free NARA microfilm page images** (Allen County upload, collection `vesselpassengercrewnewyork`): the entire **M237 (NY 1820-1897)** + **T715 (NY 1897-1957)** films, one IA item per reel, FREE + Claude-readable — **no operator/FS image download needed**. IA reel № = NARA roll №; the item `description` gives the reel's date range. Pull a page: `curl ".../download/{id}/page/n{LEAF}.jpg?scale=4"` then downsize/crop (`sips`/`magick`). ⚠ Same microfilm = same physical fold/tear/"cut-off" damage as FS (a retake-target card marks damaged frames).
+   d. **NARA Castle Garden / Balch bulk Data Files** (catalog.archives.gov NaId 4719476 → e.g. **229630481** `PAS_RS.txt`, 88 MB, pipe-delimited, **greppable locally**): rich origin-town / ship / arrival-date / birthplace fields; country codes (46=Romania, 6=Austria, 34=Galicia, 44=Russia); `ALLHDRS.txt` joins each MID → ship + arrival date. ⚠ THIN subset (Russia/Austria-Hungary-weighted; sparse Romania + post-1897) — good for bulk-grep, not comprehensive.
+   e. CEMLA (search.cemla.com) for **Buenos Aires arrivals 1882–1960** — for Italian/Spanish lines whose emigrants went to Argentina, not the US (operator types the captcha)
+   f. Try name variants: original spelling, phonetic, abbreviated, **maiden name (for women)**, Hebrew/Yiddish given name. If name + phonetic + town searches all fail across BOTH the departure and arrival indexes, the line is genuinely **un-indexed** (a whole voyage / inspection-group can be) → escalate to the manifest IMAGE by ship + date (free on IA, above), not more index searches.
 
-3. **Search naturalization records**:
-   a. FamilySearch: "[STATE] naturalization" collections
+3. **Search departure (emigration) indexes** — these are often far cleaner than the garbled US arrival index:
+   a. **Stadsarchief Rotterdam HAL passenger database** (stadsarchief.rotterdam.nl/passagierslijsten) — Rotterdam DEPARTURE side for Holland America Line ships, May 1900+; free, name-indexed. Gives ship + departure date + Yiddish/European given name, but NOT the origin town.
+   b. Other national emigration archives by origin: Hamburg (Auswanderer), Bremen, Antwerp (Red Star Line), Digitalarkivet (Norway), Emihamn (Sweden)
+   c. Use the departure index to recover the **European given name**, then re-search the US arrival manifest with that spelling.
+
+4. **Search naturalization records**:
+   a. FamilySearch "[STATE] naturalization" collections; for NYC, the SDNY/EDNY District & Circuit Court records (NARA M1972, RG 21)
    b. `"[ANCESTOR NAME]" naturalization [CITY/COUNTY] [YEAR RANGE]`
-   c. County clerk offices (many post-1906 records are indexed online)
-   d. Post-1906 naturalization records are the richest: they contain exact birthplace, birth date, arrival date, ship name, occupation, physical description
+   c. Post-1906 naturalization records are richest (exact birthplace town, birth date, arrival date, ship, occupation, physical description, witnesses)
+   d. **Caveat:** the FS naturalization INDEX often exposes only "Event Place: Manhattan / New York" — the birthplace TOWN and arrival fields are on the IMAGE only (operator-gated). Pre-1906 declarations frequently give only the country/province, not the town.
+   e. USCIS Genealogy Program — C-files / certificate files, $65/request (operator-order)
 
-4. **Data extraction**: When a record is found:
-   - Passenger manifest fields: full name, age, occupation, last residence, destination, ship name, departure port, arrival port, arrival date, traveling companions, literacy, physical description, amount of money
-   - Naturalization fields: full name, birth date, birthplace (town and country), arrival date, port, ship name, occupation, current address, witnesses
+5. **Jewish / Eastern-European line techniques**:
+   - **Landsmanshaft burial = town of origin.** NYC Jewish cemetery plots are owned by hometown societies. Search the **Mount Hebron interment DB** (mounthebroncemetery.com/interments/) and read the **Society column** — a society named for a town (e.g. "1st [Townname]er") points to that town of origin in the old country. Plot adjacency reveals spouses + disambiguates same-name dead. ⚠ A **married woman lies in her husband's** society plot, so it indicates the *household's* (his) town, not necessarily her own birthplace.
+   - **Hebrew headstone = the father's name (a free generation).** "X bar/bat Y" gives the patronymic. e.g. "Eliezer bar Yosef" yields the father's name (a free generation), often corroborated by a firstborn-namesake.
+   - **JewishGen** (free account): Unified Search → JRI-Poland (Galician/Polish vital records), Bessarabia/Romania DBs, JOWBR (burials w/ Hebrew names + parents), JGFF (researcher/cousin matches by surname+town), Communities/Gazetteer (town IDs). Search the **original European spelling** (US forms over-match on Soundex). Gesher Galicia's **All-Galicia DB** (gesher-galicia.org) is separate, for pre-1916 Galician births.
+   - **Yad Vashem Shoah Names DB** (collections.yadvashem.org/en/names) — Pages of Testimony name parents/spouse/birthplace; use the field-specific Place-of-Birth advanced URL. Only bridges a generation if a relative survived to submit; verify the record's actual town (synonyms mis-resolve).
+   - **Check whether the European vital records even survive** before chasing them: some pre-1919 Galician Jewish registers are lost (check the Gesher Galicia district inventory) — a "town identified, records gone" result is a valid, loggable endpoint.
 
-5. **Cross-reference**: Compare extracted data against existing vault files. Does the birth date match? Does the birthplace narrow down a region? Are traveling companions family members?
+6. **NYC certificate images** (the source that breaks maiden-name + parents + birth-town walls): **NYC Historical Vital Records / DORIS** (a860-historicalvitalrecords.nyc.gov) — actual birth/death/marriage CERTIFICATE IMAGES, all five boroughs, births→~1909 / marriages→~1949 / deaths→~1948. A death cert names the deceased's PARENTS + often a **birth town** where the FS index of the same cert gives only the country; a birth cert names the MOTHER'S MAIDEN NAME. Look up the cert # from the FS index, then pull the image here. Browser-only; download the image, then read it with your AI tool.
+   - **The FS-indexed version of a NYC death cert carries structured parent personas** (father/mother). Those personas let you CREATE both parents (Gen +1) on FamilySearch as a coupled, source-attached pair in one flow (an operator-gated CREATE step). ⚠ Source Linker gotcha: clicking "Add New Person" for a second parent can re-fire the first parent's still-active "Create New Person" form, producing a duplicate with the wrong name and sex. Confirm each created person's name and sex before the final Attach.
 
-6. **Update vault**: Create transcription notes for found records, update person files, update Family_Tree.md with new data, log searches in Research_Log.md.
+7. **Data extraction**: When a record is found:
+   - Passenger manifest: full name, age, occupation, last residence (= origin town), destination, ship, departure/arrival port + date, traveling companions, who joining, literacy, physical description, money
+   - Naturalization: full name, birth date, birthplace (town + country), arrival date/port/ship, occupation, address, witnesses
+   - Departure index: European given name, ship, departure date, fare register reference
+   - Cemetery/headstone: society (= town), plot, Hebrew patronymic, dates
 
-## Key Immigration Databases
+8. **Cross-reference**: Compare against existing vault files. Does the birth date match? Does the birthplace narrow a region/town? Are traveling companions or witnesses family members? Does a society/headstone corroborate a manifest origin?
+
+9. **Update your records**: Create transcription notes for found record IMAGES; update the person's entry in your tree with the new facts and citations. **Log negative results** ("searched X under spellings A/B/C, no clean match" is valuable). Label each finding **free** vs **operator-gated**. Record the session's searches and outcomes in your research log.
+
+## Key Immigration / Emigration Databases
 
 | Database | Coverage | Access |
 |---|---|---|
-| Ellis Island (libertyellisfoundation.org) | New York arrivals, 1892 to 1957 | Free |
-| Castle Garden (castlegarden.org) | New York arrivals, 1820 to 1892 | Free |
-| FamilySearch | Multiple ports, multiple countries | Free |
-| Ancestry.com | Largest indexed collection | Subscription |
-| Emigration records by country | Varies (Digitalarkivet for Norway, Emihamn for Sweden, etc.) | Varies |
-| USCIS Genealogy Program | Naturalization certificates, 1906 to 1956 | $65 per request |
+| Steve Morse One-Step (stevemorse.org) | NY arrivals — Gold Form 1892–1924 (JewishGen EIDB), White Form 1820–1957; phonetic/missing-manifest tools | Free (GET-serialize to drive) |
+| ~~Castle Garden (castlegarden.org)~~ — **DEFUNCT** → FamilySearch collection **1849782** | NY arrivals 1820–1891 (pre-Ellis) | Free |
+| **Internet Archive NARA microfilm reels** (`vesselpassengercrewnewyork`) | Full M237 (1820-1897) + T715 (1897-1957) NY manifest IMAGES, one item/reel | Free (Claude-readable; reel№=roll№) |
+| **NARA Castle Garden/Balch bulk Data Files** (catalog.archives.gov NaId 4719476) | Greppable passenger dataset; rich origin-town/ship fields; THIN subset | Free (download + grep) |
+| **Stadsarchief Rotterdam HAL** (stadsarchief.rotterdam.nl/passagierslijsten) | Rotterdam DEPARTURE index, HAL ships 1900+ | Free (drive in Chrome) |
+| **CEMLA** (search.cemla.com) | Buenos Aires arrivals 1882–1960 | Free (operator captcha) |
+| FamilySearch | Multiple ports/countries; manifest + naturalization images | Free |
+| **NYC DORIS Historical Vital Records** (a860-historicalvitalrecords.nyc.gov) | NYC birth/death/marriage CERTIFICATE IMAGES | Free (browser; operator downloads) |
+| **Mount Hebron interment DB** (mounthebroncemetery.com/interments/) | NYC Jewish burials; Society = hometown | Free |
+| **JewishGen** (jewishgen.org/databases/all/) | JRI-Poland, Bessarabia, JOWBR, JGFF, Gazetteer | Free account |
+| **Gesher Galicia All-Galicia DB** (gesher-galicia.org) | Galician vital/cadastral records | Free / member |
+| **Yad Vashem Shoah Names** (collections.yadvashem.org/en/names) | Holocaust victims; parents/spouse/birthplace | Free |
+| Ancestry.com | Largest indexed manifest/naturalization collection | Subscription (operator) |
+| USCIS Genealogy Program | Naturalization C-files, 1906–1956 | $65/request (operator) |
 
 ## Name Variation Strategies
 
 When searching for an immigrant ancestor, try:
-- Original language spelling (e.g., Nordlie, not Nordli)
-- Phonetic variants (Nowak / Novak / Novack)
+- Original-language spelling (search the European form, not the Americanized one)
+- Phonetic variants (try every plausible transliteration of the surname)
+- Hebrew/Yiddish given name (the secular name often differs from the religious given name)
 - Shortened forms (Chas. for Charles, Wm. for William)
-- Maiden name for married women
-- Patronymic (for Scandinavians: Antonsen, Rasmusen)
-- Farm name or place name (for Scandinavians)
+- Maiden name for married women (spouses often arrived separately under it)
+- Patronymic / farm name (Scandinavian: Antonsen; Rasmusen)
 - Both "old country" and Americanized versions
+
+## Recording worked-line status
+
+When a line has been worked end-to-end, record its post-work status in your research log — confirmed records, current walls, and untried free avenues — so future runs do not re-run exhausted negatives. Keep that per-line research status in your logs, not in this prompt.


### PR DESCRIPTION
## Summary

Two prompts get substantial, model-agnostic upgrades drawn from real research use. Both rely only on resources/files already in the repo (all `archives/*.md` references resolve), and neither assumes a particular vault storage model.

### `prompts/11-immigration-search.md`
Adds **emigration / departure-side** research (often far cleaner than the garbled US arrival index) and a much deeper free-resource set:
- **Steve Morse One-Step** (with practical driving notes), **Internet Archive NARA microfilm reels** (free M237/T715 manifest images), **NARA/Balch bulk data files**, **Stadsarchief Rotterdam HAL**, **CEMLA** (Buenos Aires arrivals)
- **Jewish / Eastern-European techniques**: landsmanshaft-burial = town of origin, Hebrew-headstone patronymics, JewishGen / Gesher Galicia / Yad Vashem, and checking whether European registers even survive
- **NYC DORIS** certificate images (parents / mother's-maiden-name the FS index omits)
- New guards: garbled/never-indexed manifests, separately-emigrating spouses, same-name disambiguation before merging

### `prompts/01-tree-expansion.md`
- Optional **`[SCOPE]`** to focus expansion on a subset / region
- **Check your logs before searching** to avoid repeating negative searches
- **Country-specific archive-guide routing** — read the relevant `archives/*.md` before searching a foreign line

🤖 Generated with [Claude Code](https://claude.com/claude-code)