### PR TITLE
Add optional identity/graph keys to person frontmatter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Each numbered prompt must include an `Inputs To Replace` section before `## Auto
 
 - All vault files use YAML frontmatter with at minimum: `type`, `created`, `tags`
 - Person files add: `name`, `born`, `died`, `life_status`, `family`, `evidence_tier`, `profile_status`, `sources`
+- Person files may optionally add: `id` (stable vault key), `generation`, `parents`, `spouse`, `flags` — identity and graph fields, safe to omit
 - Transcription files add: `source`, `document_type`, `person`, `date`, `ocr_method`, `ocr_quality`
 - Region and surname files add: `evidence_tier`
 - Wikilinks (`[[File_Name]]`) connect files within the vault

--- a/vault-template/templates/person.md
+++ b/vault-template/templates/person.md
@@ -7,6 +7,11 @@ life_status: living | deceased | unknown
 family: "[Surname]"
 evidence_tier: strong_signal | moderate_signal | speculative
 profile_status: complete | partial | stub
+id: P-XXXXXX              # vault-owned stable key: "P-" + 6 Crockford base32 (no I/L/O/U)
+generation: N             # integer, counted from the anchor/subject
+parents: []               # list of parent ids, e.g. [P-AAAAAA, P-BBBBBB]
+spouse: []                # list of spouse ids
+flags: []                 # e.g. [Q12, dup]
 sources:
   - "[Source 1]"
   - "[Source 2]"


### PR DESCRIPTION
## What
Five OPTIONAL keys added to the person-file frontmatter template
(`vault-template/templates/person.md`), documented in `CLAUDE.md`:

- `id` — a stable, vault-owned key (`P-` + 6 Crockford base32, no I/L/O/U).
- `generation` — integer, counted from the anchor/subject.
- `parents` / `spouse` — lists of person `id`s (the family graph as edges).
- `flags` — freeform markers (e.g. `Q12`, `dup`).

They sit between `profile_status` and `sources`; each carries a one-line inline
comment. +6 lines total, no code changes.

## Why
Past a few hundred people, a tree needs three things names and dates can't give it:
a key that survives renames and record merges (`id`), an explicit generation rather
than one inferred from layout (`generation`), and the parent/spouse relationships as
machine-readable edges (`parents`/`spouse`). These are the fields large trees end up
inventing ad hoc; standardizing the spelling in the template lets tooling rely on them
without prescribing that anyone use them.

## Compatibility
Fully optional and additive. A person file that omits every one of these keys validates
exactly as before — they are free-form-tolerant like `born`/`died`, and the validator
presence-checks required fields without rejecting extra ones. `validate-repo` passes
green. No script reads these keys yet; this PR only establishes the vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
